### PR TITLE
Add dependency link for DateTime::Format::RSS

### DIFF
--- a/podarchive.pl
+++ b/podarchive.pl
@@ -7,7 +7,7 @@ use File::Basename;
 use File::Spec; # https://perldoc.perl.org/File/Spec.html
 use XML::RSS::Parser; # https://metacpan.org/pod/XML::RSS::Parser
 use FileHandle;
-use DateTime::Format::RSS;
+use DateTime::Format::RSS; # https://metacpan.org/pod/DateTime::Format::RSS
 
 # Prevent "wide character in string" messages (some show notes contain Emojis and other UTF-8 characters)
 use open qw(:std :utf8);


### PR DESCRIPTION
Adds a link for where to install dependency for `DateTime::Format::RSS`, similar to other links in header. (My local install did not have this, resulting in an error at runtime.)